### PR TITLE
Handle overlord becoming subject

### DIFF
--- a/common/on_actions/iisc_on_actions.txt
+++ b/common/on_actions/iisc_on_actions.txt
@@ -32,6 +32,14 @@ on_join_federation = {
 	}
 }
 
+# This = subject
+# From = subject's overlord
+on_becoming_subject = {
+	events = {
+		iisc_corps.100
+	}
+}
+
 # A country has increased the level of a tech, use last_increased_tech trigger to check tech and level.
 # This = Country
 on_tech_increased = {

--- a/common/scripted_effects/iisc_corps_effects.txt
+++ b/common/scripted_effects/iisc_corps_effects.txt
@@ -69,6 +69,7 @@ iisc_disband_corp = {
 						has_planet_flag = iisc_hq_of_@prevprevprev
 					}
 					save_event_target_as = iisc_hq_planet
+					remove_planet_flag = iisc_hq_of_@prevprevprev
 					prevprevprev = {
 						iisc_remove_hq_deposit_from_corp = yes
 					}

--- a/common/scripted_effects/iisc_corps_effects.txt
+++ b/common/scripted_effects/iisc_corps_effects.txt
@@ -47,6 +47,93 @@ iisc_get_overlord = {
 	}
 }
 
+# this = corp
+# overlord = the new overlord
+iisc_disband_corp = {
+	if = {
+		limit = {
+			exists = overlord
+		}
+		# load (old) hq
+		# remove hq deposit
+		overlord = {
+			random_subject = {
+				limit = {
+					iisc_can_have_space_corp = yes
+					any_owned_planet = {
+						has_planet_flag = iisc_hq_of_@prevprevprev
+					}
+				}
+				random_owned_planet = {
+					limit = {
+						has_planet_flag = iisc_hq_of_@prevprevprev
+					}
+					save_event_target_as = iisc_hq_planet
+					prevprevprev = {
+						iisc_remove_hq_deposit_from_corp = yes
+					}
+				}
+			}
+		}
+		# give some of the money to the corps of the overlord
+		if = {
+			limit = {
+				check_variable = {
+					which = iisc_corp_money
+					value > 0
+				}
+			}
+			divide_variable = {
+				which = iisc_corp_money
+				value = 5
+			}
+			set_variable = {
+				which = iisc_corp_money_to_give
+				value = iisc_corp_money
+			}
+			overlord = {
+				while = {
+					count = 3
+					# select a random corp
+					random_subject = {
+						limit = {
+							is_country_type = iisc_space_corporation
+							prev = {
+								any_owned_planet = {
+									has_planet_flag = iisc_hq_of_@prevprev
+								}
+							}
+						}
+						set_variable = {
+							which = iisc_corp_money_to_give
+							value = prevprev
+						}
+						iisc_add_variable_resource = {
+							AMOUNT = iisc_corp_money_to_give
+							RESOURCE = energy
+						}
+						# cleanup
+						set_variable = {
+							which = iisc_corp_money_to_give
+							value = 0
+						}
+					}
+				}
+			}
+		}
+	}
+	every_mining_station = {
+		delete_fleet = this
+	}
+	every_research_station = {
+		delete_fleet = this
+	}
+	every_owned_fleet = {
+		delete_fleet = this
+	}
+	destroy_country = yes
+}
+
 # this = overlord
 iisc_give_tech_overlord_and_corps = {
 	give_technology = {

--- a/common/scripted_effects/iisc_hq_deposits_effects.txt
+++ b/common/scripted_effects/iisc_hq_deposits_effects.txt
@@ -420,3 +420,84 @@ iisc_downgrade_hq_deposit = {
 		}
 	}
 }
+
+# this = corp
+# hq set
+# this removes ALL of the deposits added by this corp
+iisc_remove_hq_deposit_from_corp = {
+	switch = {
+		trigger = has_civic
+		iisc_civic_research_consortium = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_research_consortium
+			}
+		}
+		iisc_civic_engineering_firm = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_engineering_firm
+			}
+		}
+		iisc_civic_mining_union = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_mining_union
+			}
+		}
+		iisc_civic_security_force = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_security_force
+			}
+		}
+		iisc_civic_logistics_agency = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_logistics_agency
+			}
+		}
+		iisc_civic_exploration_initiative = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_exploration_initiative
+			}
+		}
+		iisc_civic_financial_group = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_financial_group
+			}
+		}
+	}
+}
+
+# this = corp
+# hq set
+iisc_remove_hq_deposit_from_corp_aux = {
+	event_target:iisc_hq_planet = {
+		remove_deposit = $TYPE$_machine_1
+		remove_deposit = $TYPE$_machine_2
+		remove_deposit = $TYPE$_machine_3
+		remove_deposit = $TYPE$_machine_4
+		remove_deposit = $TYPE$_machine_5
+		remove_deposit = $TYPE$_machine_6
+		remove_deposit = $TYPE$_machine_7
+		remove_deposit = $TYPE$_machine_8
+		remove_deposit = $TYPE$_machine_9
+		remove_deposit = $TYPE$_machine_10
+		remove_deposit = $TYPE$_hive_1
+		remove_deposit = $TYPE$_hive_2
+		remove_deposit = $TYPE$_hive_3
+		remove_deposit = $TYPE$_hive_4
+		remove_deposit = $TYPE$_hive_5
+		remove_deposit = $TYPE$_hive_6
+		remove_deposit = $TYPE$_hive_7
+		remove_deposit = $TYPE$_hive_8
+		remove_deposit = $TYPE$_hive_9
+		remove_deposit = $TYPE$_hive_10
+		remove_deposit = $TYPE$_regular_1
+		remove_deposit = $TYPE$_regular_2
+		remove_deposit = $TYPE$_regular_3
+		remove_deposit = $TYPE$_regular_4
+		remove_deposit = $TYPE$_regular_5
+		remove_deposit = $TYPE$_regular_6
+		remove_deposit = $TYPE$_regular_7
+		remove_deposit = $TYPE$_regular_8
+		remove_deposit = $TYPE$_regular_9
+		remove_deposit = $TYPE$_regular_10
+	}
+}

--- a/events/iisc_corps_events.txt
+++ b/events/iisc_corps_events.txt
@@ -436,6 +436,8 @@ country_event = {
 				# disband the corp
 				iisc_disband_corp = yes
 			}
+			# if necessary in the future:
+			# iisc_count_corps = yes
 		}
 	}
 }

--- a/events/iisc_corps_events.txt
+++ b/events/iisc_corps_events.txt
@@ -408,3 +408,34 @@ country_event = {
 		}
 	}
 }
+
+# This = subject
+# From = subject's overlord
+country_event = {
+	id = iisc_corps.100
+	hide_window = yes
+	is_triggered_only = yes
+	trigger = {
+		iisc_can_have_space_corp = yes
+	}
+	immediate = {
+		# selects the old corp of this
+		from = {
+			every_subject = {
+				limit = {
+					is_country_type = iisc_space_corporation
+					# which hq isn't owned by the new overlord
+					NOT = {
+						prev = {
+							any_owned_planet = {
+								has_planet_flag = iisc_hq_of_@prevprev
+							}
+						}
+					}
+				}
+				# disband the corp
+				iisc_disband_corp = yes
+			}
+		}
+	}
+}

--- a/events/iisc_registry_events.txt
+++ b/events/iisc_registry_events.txt
@@ -57,7 +57,7 @@ country_event = {
 						which = iisc_registry_length
 						value = 1
 					}
-				}				
+				}
 			}
 		}
 		country_event = {
@@ -173,9 +173,8 @@ country_event = {
 							is_same_value = ROOT
 						}
 						has_communications = ROOT
-						check_variable = {
-							which = iisc_number_of_corps
-							value > 0
+						any_subject = {
+							is_country_type = iisc_space_corporation
 						}
 					}
 				}
@@ -537,9 +536,8 @@ country_event = {
 					is_same_value = ROOT
 				}
 				has_communications = ROOT
-				check_variable = {
-					which = iisc_number_of_corps
-					value > 0
+				any_subject = {
+					is_country_type = iisc_space_corporation
 				}
 			}
 			PREV = {


### PR DESCRIPTION
The way the corps of the old overlord get handled:

hq deposits are removed (so that new corps won't have trouble with it)
60% of the disbanded corp money (if positive) get attributed to up to 3 random corps of the new overlord
All mining stations and science stations get destroyed. Maybe scitch ownership to corps/player in a future update?
All fleets get destroyed.
Finally the corp get destroyed