### PR TITLE
Feat handle overlord disconnection

### DIFF
--- a/common/on_actions/iisc_on_actions.txt
+++ b/common/on_actions/iisc_on_actions.txt
@@ -10,12 +10,6 @@ on_yearly_pulse_country = {
 	}
 }
 
-on_monthly_pulse = {
-	events = {
-		iisc_pulse.20
-	}
-}
-
 # This = target country (player)
 # From = source country
 on_custom_diplomacy = {

--- a/common/on_actions/iisc_on_actions.txt
+++ b/common/on_actions/iisc_on_actions.txt
@@ -32,6 +32,14 @@ on_join_federation = {
 	}
 }
 
+# This = subject
+# From = subject's overlord
+on_becoming_subject = {
+	events = {
+		iisc_corps.100
+	}
+}
+
 # A country has increased the level of a tech, use last_increased_tech trigger to check tech and level.
 # This = Country
 on_tech_increased = {

--- a/common/scripted_effects/iisc_corps_effects.txt
+++ b/common/scripted_effects/iisc_corps_effects.txt
@@ -69,6 +69,7 @@ iisc_disband_corp = {
 						has_planet_flag = iisc_hq_of_@prevprevprev
 					}
 					save_event_target_as = iisc_hq_planet
+					remove_planet_flag = iisc_hq_of_@prevprevprev
 					prevprevprev = {
 						iisc_remove_hq_deposit_from_corp = yes
 					}

--- a/common/scripted_effects/iisc_corps_effects.txt
+++ b/common/scripted_effects/iisc_corps_effects.txt
@@ -47,6 +47,93 @@ iisc_get_overlord = {
 	}
 }
 
+# this = corp
+# overlord = the new overlord
+iisc_disband_corp = {
+	if = {
+		limit = {
+			exists = overlord
+		}
+		# load (old) hq
+		# remove hq deposit
+		overlord = {
+			random_subject = {
+				limit = {
+					iisc_can_have_space_corp = yes
+					any_owned_planet = {
+						has_planet_flag = iisc_hq_of_@prevprevprev
+					}
+				}
+				random_owned_planet = {
+					limit = {
+						has_planet_flag = iisc_hq_of_@prevprevprev
+					}
+					save_event_target_as = iisc_hq_planet
+					prevprevprev = {
+						iisc_remove_hq_deposit_from_corp = yes
+					}
+				}
+			}
+		}
+		# give some of the money to the corps of the overlord
+		if = {
+			limit = {
+				check_variable = {
+					which = iisc_corp_money
+					value > 0
+				}
+			}
+			divide_variable = {
+				which = iisc_corp_money
+				value = 5
+			}
+			set_variable = {
+				which = iisc_corp_money_to_give
+				value = iisc_corp_money
+			}
+			overlord = {
+				while = {
+					count = 3
+					# select a random corp
+					random_subject = {
+						limit = {
+							is_country_type = iisc_space_corporation
+							prev = {
+								any_owned_planet = {
+									has_planet_flag = iisc_hq_of_@prevprev
+								}
+							}
+						}
+						set_variable = {
+							which = iisc_corp_money_to_give
+							value = prevprev
+						}
+						iisc_add_variable_resource = {
+							AMOUNT = iisc_corp_money_to_give
+							RESOURCE = energy
+						}
+						# cleanup
+						set_variable = {
+							which = iisc_corp_money_to_give
+							value = 0
+						}
+					}
+				}
+			}
+		}
+	}
+	every_mining_station = {
+		delete_fleet = this
+	}
+	every_research_station = {
+		delete_fleet = this
+	}
+	every_owned_fleet = {
+		delete_fleet = this
+	}
+	destroy_country = yes
+}
+
 # this = overlord
 iisc_give_tech_overlord_and_corps = {
 	give_technology = {

--- a/common/scripted_effects/iisc_corps_effects.txt
+++ b/common/scripted_effects/iisc_corps_effects.txt
@@ -54,6 +54,9 @@ iisc_handle_corp_connection_to_overlord = {
 				event_target:iisc_hq_planet.owner = {
 					iisc_can_have_space_corp = no
 				}
+				event_target:iisc_hq_planet.owner = {
+					is_subject = yes
+				}
 			}
 		}
 		iisc_destroy_corp = yes

--- a/common/scripted_effects/iisc_corps_effects.txt
+++ b/common/scripted_effects/iisc_corps_effects.txt
@@ -90,8 +90,55 @@ iisc_handle_corp_connection_to_overlord = {
 }
 
 # this = corp
-# overlord = the new overlord
-iisc_disband_corp = {
+# corp is supposed to be destroyed => its money is copied, not transferred
+# overlord exists
+iisc_split_disbanded_corp_money = {
+	if = {
+		limit = {
+			check_variable = {
+				which = iisc_corp_money
+				value > 0
+			}
+		}
+		divide_variable = {
+			which = iisc_corp_money
+			value = 5
+		}
+		set_variable = {
+			which = iisc_corp_money_to_give
+			value = iisc_corp_money
+		}
+		overlord = {
+			while = {
+				count = 3
+				# select a random corp
+				random_subject = {
+					limit = {
+						is_country_type = iisc_space_corporation
+						iisc_is_corp_connected = yes
+					}
+					set_variable = {
+						which = iisc_corp_money_to_give
+						value = prevprev
+					}
+					iisc_add_variable_resource = {
+						AMOUNT = iisc_corp_money_to_give
+						RESOURCE = energy
+					}
+					# cleanup
+					set_variable = {
+						which = iisc_corp_money_to_give
+						value = 0
+					}
+				}
+			}
+		}
+	}
+}
+
+# this = corp
+# overlord = the new overlord (should exist)
+iisc_disband_disconnected_corp = {
 	if = {
 		limit = {
 			is_country_type = iisc_space_corporation
@@ -102,7 +149,7 @@ iisc_disband_corp = {
 				exists = overlord
 			}
 			# load (old) hq
-			# remove hq deposit
+			# removal of hq deposit is done afterwards in iisc_destroy_corp
 			overlord = {
 				random_subject = {
 					limit = {
@@ -116,88 +163,35 @@ iisc_disband_corp = {
 							has_planet_flag = iisc_hq_of_@prevprevprev
 						}
 						save_event_target_as = iisc_hq_planet
-						remove_planet_flag = iisc_hq_of_@prevprevprev
-						prevprevprev = {
-							iisc_remove_hq_deposit_from_corp = yes
-						}
 					}
 				}
 			}
 			# give some of the money to the corps of the overlord
-			if = {
-				limit = {
-					check_variable = {
-						which = iisc_corp_money
-						value > 0
-					}
-				}
-				divide_variable = {
-					which = iisc_corp_money
-					value = 5
-				}
-				set_variable = {
-					which = iisc_corp_money_to_give
-					value = iisc_corp_money
-				}
-				overlord = {
-					while = {
-						count = 3
-						# select a random corp
-						random_subject = {
-							limit = {
-								is_country_type = iisc_space_corporation
-								prev = {
-									any_owned_planet = {
-										has_planet_flag = iisc_hq_of_@prevprev
-									}
-								}
-							}
-							set_variable = {
-								which = iisc_corp_money_to_give
-								value = prevprev
-							}
-							iisc_add_variable_resource = {
-								AMOUNT = iisc_corp_money_to_give
-								RESOURCE = energy
-							}
-							# cleanup
-							set_variable = {
-								which = iisc_corp_money_to_give
-								value = 0
-							}
-						}
-					}
-				}
-			}
+			iisc_split_disbanded_corp_money = yes
 		}
-		every_mining_station = {
-			delete_fleet = this
-		}
-		every_research_station = {
-			delete_fleet = this
-		}
-		every_owned_fleet = {
-			delete_fleet = this
-		}
-		destroy_country = yes
+		iisc_destroy_corp = yes
 	}
 	else = {
-		log = "Tried to disband non corp country by iisc_disband_corp"
+		log = "Tried to disband non corp country by iisc_disband_disconnected_corp"
 	}
 }
 
 # this = corp
-# hq set and exists
 iisc_destroy_corp = {
 	if = {
 		limit = {
 			is_country_type = iisc_space_corporation
 		}
 		# just a redundant check
-		event_target:iisc_hq_planet = {
-			remove_planet_flag = iisc_hq_of_@prev
+		if = {
+			limit = {
+				exists = event_target:iisc_hq_planet
+			}
+			event_target:iisc_hq_planet = {
+				remove_planet_flag = iisc_hq_of_@prev
+			}
+			iisc_remove_hq_deposit_from_corp = yes
 		}
-		iisc_remove_hq_deposit_from_corp = yes
 		every_mining_station = {
 			delete_fleet = this
 		}

--- a/common/scripted_effects/iisc_corps_effects.txt
+++ b/common/scripted_effects/iisc_corps_effects.txt
@@ -20,11 +20,6 @@ iisc_set_hq = {
 			}
 		}
 		set_country_flag = iisc_hq_set
-		event_target:iisc_hq_planet = {
-			prev = {
-				set_country_flag = iisc_hq_set_on_@prev
-			}
-		}
 	}
 }
 
@@ -48,91 +43,172 @@ iisc_get_overlord = {
 }
 
 # this = corp
+# hq set and exists
+iisc_handle_corp_connection_to_overlord = {
+	if = {
+		limit = {
+			OR = {
+				NOT = {
+					exists = event_target:iisc_hq_planet.owner
+				}
+				event_target:iisc_hq_planet.owner = {
+					iisc_can_have_space_corp = no
+				}
+			}
+		}
+		iisc_destroy_corp = yes
+	}
+	else_if = {
+		# the owner exists and can have corps
+		limit = {
+			# same as a NAND without the NOTs but this way it's easier to understand
+			OR = {
+				NOT = {
+					exists = overlord
+				}
+				NOT = {
+					overlord = {
+						is_same_value = event_target:iisc_hq_planet.owner
+					}
+				}
+			}
+		}
+		# the corp is not connected
+		# we need to make it subject to the owner of the planet
+		# the owner of the planet should not be already a subject thanks to the on_becoming_subject
+		set_subject_of = {
+			who = event_target:iisc_hq_planet.owner
+			subject_type = iisc_corp_vassal
+		}
+		# if necessary in the future: scope to overlord and
+		# iisc_count_corps = yes
+		# TODO add an event with a window?
+	}
+}
+
+# this = corp
 # overlord = the new overlord
 iisc_disband_corp = {
 	if = {
 		limit = {
-			exists = overlord
+			is_country_type = iisc_space_corporation
 		}
-		# load (old) hq
-		# remove hq deposit
-		overlord = {
-			random_subject = {
-				limit = {
-					iisc_can_have_space_corp = yes
-					any_owned_planet = {
-						has_planet_flag = iisc_hq_of_@prevprevprev
-					}
-				}
-				random_owned_planet = {
-					limit = {
-						has_planet_flag = iisc_hq_of_@prevprevprev
-					}
-					save_event_target_as = iisc_hq_planet
-					remove_planet_flag = iisc_hq_of_@prevprevprev
-					prevprevprev = {
-						iisc_remove_hq_deposit_from_corp = yes
-					}
-				}
-			}
-		}
-		# give some of the money to the corps of the overlord
+		# just a redundant check
 		if = {
 			limit = {
-				check_variable = {
-					which = iisc_corp_money
-					value > 0
+				exists = overlord
+			}
+			# load (old) hq
+			# remove hq deposit
+			overlord = {
+				random_subject = {
+					limit = {
+						iisc_can_have_space_corp = yes
+						any_owned_planet = {
+							has_planet_flag = iisc_hq_of_@prevprevprev
+						}
+					}
+					random_owned_planet = {
+						limit = {
+							has_planet_flag = iisc_hq_of_@prevprevprev
+						}
+						save_event_target_as = iisc_hq_planet
+						remove_planet_flag = iisc_hq_of_@prevprevprev
+						prevprevprev = {
+							iisc_remove_hq_deposit_from_corp = yes
+						}
+					}
 				}
 			}
-			divide_variable = {
-				which = iisc_corp_money
-				value = 5
-			}
-			set_variable = {
-				which = iisc_corp_money_to_give
-				value = iisc_corp_money
-			}
-			overlord = {
-				while = {
-					count = 3
-					# select a random corp
-					random_subject = {
-						limit = {
-							is_country_type = iisc_space_corporation
-							prev = {
-								any_owned_planet = {
-									has_planet_flag = iisc_hq_of_@prevprev
+			# give some of the money to the corps of the overlord
+			if = {
+				limit = {
+					check_variable = {
+						which = iisc_corp_money
+						value > 0
+					}
+				}
+				divide_variable = {
+					which = iisc_corp_money
+					value = 5
+				}
+				set_variable = {
+					which = iisc_corp_money_to_give
+					value = iisc_corp_money
+				}
+				overlord = {
+					while = {
+						count = 3
+						# select a random corp
+						random_subject = {
+							limit = {
+								is_country_type = iisc_space_corporation
+								prev = {
+									any_owned_planet = {
+										has_planet_flag = iisc_hq_of_@prevprev
+									}
 								}
 							}
-						}
-						set_variable = {
-							which = iisc_corp_money_to_give
-							value = prevprev
-						}
-						iisc_add_variable_resource = {
-							AMOUNT = iisc_corp_money_to_give
-							RESOURCE = energy
-						}
-						# cleanup
-						set_variable = {
-							which = iisc_corp_money_to_give
-							value = 0
+							set_variable = {
+								which = iisc_corp_money_to_give
+								value = prevprev
+							}
+							iisc_add_variable_resource = {
+								AMOUNT = iisc_corp_money_to_give
+								RESOURCE = energy
+							}
+							# cleanup
+							set_variable = {
+								which = iisc_corp_money_to_give
+								value = 0
+							}
 						}
 					}
 				}
 			}
 		}
+		every_mining_station = {
+			delete_fleet = this
+		}
+		every_research_station = {
+			delete_fleet = this
+		}
+		every_owned_fleet = {
+			delete_fleet = this
+		}
+		destroy_country = yes
 	}
-	every_mining_station = {
-		delete_fleet = this
+	else = {
+		log = "Tried to disband non corp country by iisc_disband_corp"
 	}
-	every_research_station = {
-		delete_fleet = this
+}
+
+# this = corp
+# hq set and exists
+iisc_destroy_corp = {
+	if = {
+		limit = {
+			is_country_type = iisc_space_corporation
+		}
+		# just a redundant check
+		event_target:iisc_hq_planet = {
+			remove_planet_flag = iisc_hq_of_@prev
+		}
+		iisc_remove_hq_deposit_from_corp = yes
+		every_mining_station = {
+			delete_fleet = this
+		}
+		every_research_station = {
+			delete_fleet = this
+		}
+		every_owned_fleet = {
+			delete_fleet = this
+		}
+		destroy_country = yes
 	}
-	every_owned_fleet = {
-		delete_fleet = this
+	else = {
+		log = "Tried to delete non corp country by iisc_destroy_corp"
 	}
-	destroy_country = yes
 }
 
 # this = overlord
@@ -784,8 +860,8 @@ iisc_compute_income_from_hq_deposits = {
 }
 
 # this = corp
+# hq set
 iisc_compute_and_tax_space_corp_income = {
-	iisc_get_hq = yes
 	iisc_compute_passive_income = yes
 	iisc_compute_income_from_hq_deposits = yes
 	iisc_compute_and_tax_space_corp_income_from_resource = {

--- a/common/scripted_effects/iisc_creation_effects.txt
+++ b/common/scripted_effects/iisc_creation_effects.txt
@@ -28,7 +28,6 @@ iisc_create_corp = {
 		civics = random
 		auto_delete = no
 		effect = {
-			set_country_flag = iisc_corp_of_@prev
 			establish_communications_no_message = prev
 			set_subject_of = {
 				who = prev
@@ -132,8 +131,12 @@ iisc_create_corp = {
 			which = iisc_corp_money_last_month
 			value = iisc_corp_money
 		}
+		# setup recurrent monthly event
+		country_event = {
+			id = iisc_pulse.20
+			days = 1
+		}
 	}
-	set_country_flag = iisc_overlord_of_@last_created_country
 	every_country = {
 		limit = {
 			has_communications = prev

--- a/common/scripted_effects/iisc_hq_deposits_effects.txt
+++ b/common/scripted_effects/iisc_hq_deposits_effects.txt
@@ -420,3 +420,84 @@ iisc_downgrade_hq_deposit = {
 		}
 	}
 }
+
+# this = corp
+# hq set
+# this removes ALL of the deposits added by this corp
+iisc_remove_hq_deposit_from_corp = {
+	switch = {
+		trigger = has_civic
+		iisc_civic_research_consortium = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_research_consortium
+			}
+		}
+		iisc_civic_engineering_firm = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_engineering_firm
+			}
+		}
+		iisc_civic_mining_union = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_mining_union
+			}
+		}
+		iisc_civic_security_force = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_security_force
+			}
+		}
+		iisc_civic_logistics_agency = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_logistics_agency
+			}
+		}
+		iisc_civic_exploration_initiative = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_exploration_initiative
+			}
+		}
+		iisc_civic_financial_group = {
+			iisc_remove_hq_deposit_from_corp_aux = {
+				TYPE = d_iisc_financial_group
+			}
+		}
+	}
+}
+
+# this = corp
+# hq set
+iisc_remove_hq_deposit_from_corp_aux = {
+	event_target:iisc_hq_planet = {
+		remove_deposit = $TYPE$_machine_1
+		remove_deposit = $TYPE$_machine_2
+		remove_deposit = $TYPE$_machine_3
+		remove_deposit = $TYPE$_machine_4
+		remove_deposit = $TYPE$_machine_5
+		remove_deposit = $TYPE$_machine_6
+		remove_deposit = $TYPE$_machine_7
+		remove_deposit = $TYPE$_machine_8
+		remove_deposit = $TYPE$_machine_9
+		remove_deposit = $TYPE$_machine_10
+		remove_deposit = $TYPE$_hive_1
+		remove_deposit = $TYPE$_hive_2
+		remove_deposit = $TYPE$_hive_3
+		remove_deposit = $TYPE$_hive_4
+		remove_deposit = $TYPE$_hive_5
+		remove_deposit = $TYPE$_hive_6
+		remove_deposit = $TYPE$_hive_7
+		remove_deposit = $TYPE$_hive_8
+		remove_deposit = $TYPE$_hive_9
+		remove_deposit = $TYPE$_hive_10
+		remove_deposit = $TYPE$_regular_1
+		remove_deposit = $TYPE$_regular_2
+		remove_deposit = $TYPE$_regular_3
+		remove_deposit = $TYPE$_regular_4
+		remove_deposit = $TYPE$_regular_5
+		remove_deposit = $TYPE$_regular_6
+		remove_deposit = $TYPE$_regular_7
+		remove_deposit = $TYPE$_regular_8
+		remove_deposit = $TYPE$_regular_9
+		remove_deposit = $TYPE$_regular_10
+	}
+}

--- a/common/scripted_triggers/iisc_triggers.txt
+++ b/common/scripted_triggers/iisc_triggers.txt
@@ -2,6 +2,16 @@ iisc_is_space_corp_not_installed = {
 	always = no
 }
 
+# this = corp
+# overlord exists
+iisc_is_corp_connected = {
+	overlord = {
+		any_owned_planet = {
+			has_planet_flag = iisc_hq_of_@prevprev
+		}
+	}
+}
+
 # this = overlord
 iisc_can_have_space_corp = {
 	is_country_type = default

--- a/events/iisc_corps_events.txt
+++ b/events/iisc_corps_events.txt
@@ -425,16 +425,10 @@ country_event = {
 				limit = {
 					is_country_type = iisc_space_corporation
 					# which hq isn't owned by the new overlord
-					NOT = {
-						prev = {
-							any_owned_planet = {
-								has_planet_flag = iisc_hq_of_@prevprev
-							}
-						}
-					}
+					iisc_is_corp_connected = no
 				}
 				# disband the corp
-				iisc_disband_corp = yes
+				iisc_disband_disconnected_corp = yes
 			}
 			# if necessary in the future:
 			# iisc_count_corps = yes

--- a/events/iisc_corps_events.txt
+++ b/events/iisc_corps_events.txt
@@ -436,6 +436,8 @@ country_event = {
 				# disband the corp
 				iisc_disband_corp = yes
 			}
+			# if necessary in the future:
+			# iisc_count_corps = yes
 		}
 	}
 }

--- a/events/iisc_corps_events.txt
+++ b/events/iisc_corps_events.txt
@@ -408,3 +408,34 @@ country_event = {
 		}
 	}
 }
+
+# This = subject
+# From = subject's overlord
+country_event = {
+	id = iisc_corps.100
+	hide_window = yes
+	is_triggered_only = yes
+	trigger = {
+		iisc_can_have_space_corp = yes
+	}
+	immediate = {
+		# selects the old corp of this
+		from = {
+			every_subject = {
+				limit = {
+					is_country_type = iisc_space_corporation
+					# which hq isn't owned by the new overlord
+					NOT = {
+						prev = {
+							any_owned_planet = {
+								has_planet_flag = iisc_hq_of_@prevprev
+							}
+						}
+					}
+				}
+				# disband the corp
+				iisc_disband_corp = yes
+			}
+		}
+	}
+}

--- a/events/iisc_diplomacy_events.txt
+++ b/events/iisc_diplomacy_events.txt
@@ -13,12 +13,23 @@ country_event = {
 	}
 	immediate = {
 		from = {
-			iisc_get_overlord = yes
-			iisc_get_hq = yes
-			save_event_target_as = iisc_corp_country
+			if = {
+				limit = {
+					exists = overlord
+					iisc_is_corp_connected = yes
+				}
+				iisc_get_overlord = yes
+				iisc_get_hq = yes
+				save_event_target_as = iisc_corp_country
+			}
 		}
-		country_event = {
-			id = iisc_diplomacy.11
+		if = {
+			limit = {
+				exists = event_target:iisc_corp_country
+			}
+			country_event = {
+				id = iisc_diplomacy.11
+			}
 		}
 	}
 }

--- a/events/iisc_pulse_events.txt
+++ b/events/iisc_pulse_events.txt
@@ -63,6 +63,11 @@ country_event = {
 		every_subject = {
 			limit = {
 				is_country_type = iisc_space_corporation
+				overlord = {
+					any_owned_planet = {
+						has_planet_flag = iisc_hq_of_@prevprev
+					}
+				}
 			}
 			iisc_get_hq = yes
 			# performance intensive?
@@ -101,23 +106,33 @@ country_event = {
 	}
 }
 
-# monthly pulse
+# monthly pulse but fires itself
 # trigger event for corps randomly in the month
-event = {
+# hq set
+country_event = {
 	id = iisc_pulse.20
 	is_triggered_only = yes
 	hide_window = yes
 	immediate = {
 		if = {
 			limit = {
-				NOT = {
-					has_global_flag = iisc_paused
+				OR = {
+					NOT = {
+						exists = event_target:iisc_hq_planet
+					}
+					has_global_flag = iisc_stopped
 				}
 			}
-			every_country = {
+			# TODO destroy the country and cleanup
+		}
+		else = {
+			if = {
 				limit = {
-					is_country_type = iisc_space_corporation
+					NOT = {
+						has_global_flag = iisc_paused
+					}
 				}
+				iisc_handle_corp_connection_to_overlord = yes
 				country_event = {
 					id = iisc_pulse.21
 					days = 1
@@ -128,23 +143,32 @@ event = {
 					days = 1
 				}
 			}
+			country_event = {
+				id = iisc_pulse.20
+				days = 30
+			}
 		}
 	}
 }
 
 # build ships if necessary
 # checks if enough research to get a tech
-# once per month
+# once per 30 days
 # triggered by iisc_pulse.20
+# hq set
 country_event = {
 	id = iisc_pulse.21
 	is_triggered_only = yes
 	hide_window = yes
 	trigger = {
-		exists = overlord
+		exists = event_target:iisc_hq_planet
+		NOR = {
+			has_global_flag = iisc_stopped
+			has_global_flag = iisc_paused
+		}
 	}
 	immediate = {
-		iisc_get_hq = yes
+		iisc_handle_corp_connection_to_overlord = yes
 		# build ships
 		if = {
 			limit = {
@@ -204,14 +228,20 @@ country_event = {
 # compute income and taxes
 # once per month
 # triggered by iisc_pulse.20
+# hq set
 country_event = {
 	id = iisc_pulse.22
 	is_triggered_only = yes
 	hide_window = yes
 	trigger = {
-		exists = overlord
+		exists = event_target:iisc_hq_planet
+		NOR = {
+			has_global_flag = iisc_stopped
+			has_global_flag = iisc_paused
+		}
 	}
 	immediate = {
+		iisc_handle_corp_connection_to_overlord = yes
 		iisc_compute_and_tax_space_corp_income = yes
 	}
 }

--- a/events/iisc_pulse_events.txt
+++ b/events/iisc_pulse_events.txt
@@ -106,7 +106,7 @@ country_event = {
 	}
 }
 
-# monthly pulse but fires itself
+# fires itself every 30 days (doesn't use monthly_pulse)
 # trigger event for corps randomly in the month
 # hq set
 country_event = {
@@ -123,7 +123,7 @@ country_event = {
 					has_global_flag = iisc_stopped
 				}
 			}
-			# TODO destroy the country and cleanup
+			iisc_destroy_corp = yes
 		}
 		else = {
 			if = {

--- a/events/iisc_registry_events.txt
+++ b/events/iisc_registry_events.txt
@@ -57,7 +57,7 @@ country_event = {
 						which = iisc_registry_length
 						value = 1
 					}
-				}				
+				}
 			}
 		}
 		country_event = {
@@ -173,9 +173,8 @@ country_event = {
 							is_same_value = ROOT
 						}
 						has_communications = ROOT
-						check_variable = {
-							which = iisc_number_of_corps
-							value > 0
+						any_subject = {
+							is_country_type = iisc_space_corporation
 						}
 					}
 				}
@@ -537,9 +536,8 @@ country_event = {
 					is_same_value = ROOT
 				}
 				has_communications = ROOT
-				check_variable = {
-					which = iisc_number_of_corps
-					value > 0
+				any_subject = {
+					is_country_type = iisc_space_corporation
 				}
 			}
 			PREV = {

--- a/events/iisc_registry_events.txt
+++ b/events/iisc_registry_events.txt
@@ -34,6 +34,7 @@ country_event = {
 			every_subject = {
 				limit = {
 					is_country_type = iisc_space_corporation
+					iisc_is_corp_connected = yes
 				}
 				ROOT = {
 					SLEX_store_list_event_var_index = {


### PR DESCRIPTION
This is based on the other PR.

Changed the logic of the monthly pulsed event for corps:
Now there is a country event that fires itself every 30 days for each corp. It is fired at first by the creation of the corp.
Like the previous one, it fires a country event to handle the whole "build ships/deposits/..." logic between 5 and 25 days later and one country event to compute the taxes (this one won't happen every 1th month anymore, but every 30 days)

In those 3 events, the hq is already set (from the creation effect) => no need to get it
If the hq's owner is not the overlord (and if it accepts corps), set it as a new overlord
If there is no owner or if the owner doesn't accept corps, destroy the corp

This handles therefore the cases where:
- the planet is transfered to a new owner => is set as subject
- the planet is transfered to a new owner that is already a vassal => corp gets destroyed
- the planet has no owner anymore => corp gets destroyed